### PR TITLE
Fix dynamic port and socket connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ io.on('connection', (socket) => {
 });
 
 // Start the server
-const PORT = 3000;
-server.listen(PORT, "0.0.0.0",() => {
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, '0.0.0.0', () => {
     console.log(`Server is running at http://localhost:${PORT}`);
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "thecatchat",
   "version": "1.0.0",
   "description": "silly chat with cats!!! ",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/socket.io-client/dist/socket.io.js"></script>
     <script>  //in-line script, which is a simple way to add JavaScript to get the Socket.io client library and connect to the server.
-        const socket = io(':3000');  //connect to the internet address of the server
+        const socket = io();  // connect to the same host and port serving the page
         
         // Elements
         const messages = document.getElementById('messages');


### PR DESCRIPTION
## Summary
- support dynamic port from environment
- connect socket.io client to current host/port
- correct entry point in package.json

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852e20a591c832a9ad66fc40313dbcf